### PR TITLE
Pass headers to EM http request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,29 +2,41 @@ PATH
   remote: .
   specs:
     em-xmlrpc-client (1.0.1)
+      em-http-request (~> 1.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.2.6)
-    crack (0.1.8)
-    em-http-request (0.3.0)
-      addressable (>= 2.0.0)
-      escape_utils
-      eventmachine (>= 0.12.9)
-    escape_utils (0.2.3)
-    eventmachine (0.12.10)
+    addressable (2.4.0)
+    cookiejar (0.3.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    em-http-request (1.1.5)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-socksify (0.3.2)
+      eventmachine (>= 1.0.0.beta.4)
+    eventmachine (1.2.7)
+    hashdiff (0.3.7)
+    http_parser.rb (0.6.0)
     rr (1.0.3)
-    webmock (1.6.4)
-      addressable (~> 2.2, > 2.2.5)
-      crack (>= 0.1.7)
+    safe_yaml (1.0.4)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  em-http-request
   em-xmlrpc-client!
   eventmachine
   rr
   webmock
+
+BUNDLED WITH
+   1.16.2

--- a/em-xmlrpc-client.gemspec
+++ b/em-xmlrpc-client.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "em-http-request", "~> 1.0"
+
   # specify any dependencies here; for example:
   s.add_development_dependency "eventmachine"
-  s.add_development_dependency "em-http-request"
   s.add_development_dependency "webmock"
   s.add_development_dependency "rr"
 

--- a/lib/em-xmlrpc-client.rb
+++ b/lib/em-xmlrpc-client.rb
@@ -128,7 +128,7 @@ module XMLRPC
       conn_opts = @connection_options || {}
       conn_opts[:ssl] = @ssl_options if @ssl_options
 
-      http = EM::HttpRequest.new("http://#{@host}:#{@port}#{@path}", conn_opts).post :body => request, :timeout => @timeout
+      http = EM::HttpRequest.new("http://#{@host}:#{@port}#{@path}", conn_opts).post :body => request, :head => header, :timeout => @timeout
       http.callback{ fiber.resume }
       http.errback do
         # Unfortunately, we can't determine exactly what the error is using EventMachine < 1.0.

--- a/test/test_em-xmlrpc-client.rb
+++ b/test/test_em-xmlrpc-client.rb
@@ -2,19 +2,30 @@ require 'helper'
 
 class TestEmXmlrpcClient < Test::Unit::TestCase
 
+  EXTRA_HEADER = { "Authorization" => "custom" }
+  EXPECTED_ANSWER = {
+    "zoneId" => 55, "publisherId" => 6, "zoneName" => "Telegraph ATW",
+    "type" => 0, "width" => 150, "height" => 150, "capping" => 0,
+    "sessionCapping" => 0, "block" => 0, "comments" => "", "append" => "",
+    "prepend" => ""
+  }
+
   def test_em_http
     host = "localhost"
     path = "api/v2/xmlrpc"
-    stub_request(:post, "http://#{host}/#{path}").to_return(File.read("test/data/response"))
-    expected = {"zoneId"=>55, "publisherId"=>6, "zoneName"=>"Telegraph ATW", "type"=>0, "width"=>150, "height"=>150, "capping"=>0, "sessionCapping"=>0, "block"=>0, "comments"=>"", "append"=>"", "prepend"=>""}
+    stub_request(:post, "http://#{host}/#{path}").
+      with(headers: EXTRA_HEADER).
+      to_return(File.read("test/data/response"))
 
     EM.run do
       Fiber.new do
         client = XMLRPC::Client.new2("http://#{host}/#{path}")
+        client.http_header_extra = EXTRA_HEADER
+
         mock.proxy(client).do_rpc_em_http(anything, anything, anything)
         mock(client).do_rpc_net_http.never
         actual = client.call("ox.getZone", "phpads4e32f100507466.86347358", 54)
-        assert_equal expected, actual
+        assert_equal EXPECTED_ANSWER, actual
         EM.stop
       end.resume
     end
@@ -23,14 +34,16 @@ class TestEmXmlrpcClient < Test::Unit::TestCase
   def test_net_http
     host = "localhost"
     path = "api/v2/xmlrpc"
-    stub_request(:post, "http://#{host}/#{path}").to_return(File.read("test/data/response"))
-    expected = {"zoneId"=>55, "publisherId"=>6, "zoneName"=>"Telegraph ATW", "type"=>0, "width"=>150, "height"=>150, "capping"=>0, "sessionCapping"=>0, "block"=>0, "comments"=>"", "append"=>"", "prepend"=>""}
+    stub_request(:post, "http://#{host}/#{path}").
+      with(headers: EXTRA_HEADER).
+      to_return(File.read("test/data/response"))
 
     client = XMLRPC::Client.new2("http://#{host}/#{path}")
+    client.http_header_extra = EXTRA_HEADER
+
     mock(client).do_rpc_em_http.never
     mock.proxy(client).do_rpc_net_http(anything, anything, anything)
     actual = client.call("ox.getZone", "phpads4e32f100507466.86347358", 54)
-    assert_equal expected, actual
+    assert_equal EXPECTED_ANSWER, actual
   end
-
 end


### PR DESCRIPTION
Hi!

This introduces ability to provide HTTP headers to EM http request, to make it on par with the net/http driver and fixes #1 

